### PR TITLE
Add preliminary DreamcastParser to PyRomInfo

### DIFF
--- a/pyrominfo/dreamcast.py
+++ b/pyrominfo/dreamcast.py
@@ -19,6 +19,8 @@ class DreamcastParser(RomInfoParser):
     * http://thekickback.com/dreamcast/GD-ROM%20Format%20Basic%20Specifications%20v2.14.pdf
     * Image reader code of the reicast-emulator project:
     * https://github.com/reicast/reicast-emulator/tree/master/core/imgread
+    * IP0000.BIN documentation:
+    * https://www.dropbox.com/s/ithnw69wy3ciuzn/IP0000.BIN.txt
     """
 
     def getValidExtensions(self):
@@ -186,7 +188,7 @@ class DreamcastParser(RomInfoParser):
                 'media_id',
                 'media_info_code',
                 'region_code',
-                'compatible_peripherals',
+                'compatible_peripherals_code',
                 'product_id',
                 'product_version',
                 'release_date_code',
@@ -196,6 +198,12 @@ class DreamcastParser(RomInfoParser):
 
         props = dict(zip(keys, ip_info))
         try:
+            peripherals_code = int(props['compatible_peripherals_code'], 16)
+            peripherals = []
+            for p_code, p_desc in dc_peripherals.items():
+                if peripherals_code & p_code == p_code:
+                    peripherals.append(p_desc)
+            props['compatible_peripherals'] = tuple(peripherals)
             props['media_info'] = tuple(
                 int(x) for x in props['media_info_code'][6:].split('/'))
             props['release_date'] = datetime.date(
@@ -229,4 +237,32 @@ dc_regions = {
     'J': 'Asia',     # Japan, Korea, Asian NTSC
     'U': 'America',  # North American NTSC, Brazilian PAL-M, Argentine PAL-N
     'E': 'Europe'    # European PAL
+}
+
+dc_peripherals = {
+    0b0000000000000000000000000001: 'Uses Windows CE',
+    0b0000000000000000000000010000: 'VGA box support',
+    # Expansion units
+    0b0000000000000000000100000000: 'Other expansions',
+    0b0000000000000000001000000000: 'Puru Puru pack',
+    0b0000000000000000010000000000: 'Mike device',
+    0b0000000000000000100000000000: 'Memory card',
+    # Required peripherals
+    0b0000000000000001000000000000: 'Start/A/B/Directions',
+    0b0000000000000010000000000000: 'C button',
+    0b0000000000000100000000000000: 'D button',
+    0b0000000000001000000000000000: 'X button',
+    0b0000000000010000000000000000: 'Y button',
+    0b0000000000100000000000000000: 'Z button',
+    0b0000000001000000000000000000: 'Expanded direction buttons',
+    0b0000000010000000000000000000: 'Analog R trigger',
+    0b0000000100000000000000000000: 'Analog L trigger',
+    0b0000001000000000000000000000: 'Analog horizontal controller',
+    0b0000010000000000000000000000: 'Analog vertical controller',
+    0b0000100000000000000000000000: 'Expanded analog horizontal',
+    0b0001000000000000000000000000: 'Expanded analog vertical',
+    # Optional peripherals
+    0b0010000000000000000000000000: 'Gun',
+    0b0100000000000000000000000000: 'Keyboard',
+    0b1000000000000000000000000000: 'Mouse'
 }

--- a/pyrominfo/dreamcast.py
+++ b/pyrominfo/dreamcast.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2015 Jan Holthuis
+# See Copyright Notice in rominfo.py
+
+import os
+import struct
+from rominfo import RomInfoParser
+
+
+class DreamcastParser(RomInfoParser):
+    """
+    Parse a Dreamcast image. Valid extensions is cdi (little endian byte
+    order), although gdi support is desired, too. This parser is derived from:
+    * https://gist.github.com/Holzhaus/ae3dacf6a2e83dd00421
+    Other related documentation and source code:
+    * GD-ROM Format Basic Specifications Ver. 2.14 by Sega Enterprises, Ltd.
+    * http://thekickback.com/dreamcast/GD-ROM%20Format%20Basic%20Specifications%20v2.14.pdf
+    * Image reader code of the reicast-emulator project:
+    * https://github.com/reicast/reicast-emulator/tree/master/core/imgread
+    """
+
+    def getValidExtensions(self):
+        # TODO: Improve cdi support
+        # TODO: Add gdi support
+        return ["cdi"]
+
+    def parse(self, filename):
+        props = {}
+        file_size = os.path.getsize(filename)
+        if file_size < 8:
+            print("Image size too short")
+            return props
+
+        with open(filename, mode="rb") as f:
+            f.seek(file_size-8)
+            image_version = struct.unpack("<I", f.read(4))[0]
+            image_header_offset = struct.unpack("<I", f.read(4))[0]
+
+            if image_header_offset == 0:
+                print("Bad image format")
+                return props
+
+            if image_version not in (CDI_V2, CDI_V3, CDI_V35):
+                print("Unsupported CDI version!")
+                return props
+
+            f.seek(image_header_offset)
+            num_sessions = struct.unpack("<H", f.read(2))[0]
+
+            last_data_track_info = (None, None)
+            track_offset = 0
+            for s in range(num_sessions):
+                num_tracks = struct.unpack("<H", f.read(2))[0]
+
+                for t in range(num_tracks):
+                    temp_value = struct.unpack("<I", f.read(4))[0]
+                    if temp_value != 0:
+                        # extra data (DJ 3.00.780 and up)
+                        f.seek(8, 1)
+
+                    current_start_mark = struct.unpack("<10B", f.read(10))
+                    if current_start_mark != cdi_track_start_mark:
+                        print("Unsupported format: Missing track start mark")
+                        return props
+
+                    current_start_mark = struct.unpack("<10B", f.read(10))
+                    if current_start_mark != cdi_track_start_mark:
+                        print("Unsupported format: Missing track start mark")
+                        return props
+
+                    f.seek(4, 1)
+                    filename_length = struct.unpack("<B", f.read(1))[0]
+                    filename = f.read(filename_length).decode('utf-8')
+
+                    f.seek(11, 1)
+                    f.seek(4, 1)
+                    f.seek(4, 1)
+                    temp_value = struct.unpack("<I", f.read(4))[0]
+                    if temp_value == 0x80000000:
+                        # DiscJuggler 4
+                        f.seek(8, 1)
+                    f.seek(2, 1)
+                    track_pregap_length = struct.unpack("<I", f.read(4))[0]
+                    track_length = struct.unpack("<I", f.read(4))[0]
+                    f.seek(6, 1)
+                    track_mode = struct.unpack("<I", f.read(4))[0]
+                    f.seek(12, 1)
+                    track_start_lba = struct.unpack("<I", f.read(4))[0]
+                    track_total_length = struct.unpack("<I", f.read(4))[0]
+                    f.seek(16, 1)
+                    sector_size_id = struct.unpack("<I", f.read(4))[0]
+
+                    if sector_size_id not in cdi_track_sector_sizes:
+                        print("Unsupported sector size")
+                        return
+                    track_sector_size = cdi_track_sector_sizes[sector_size_id]
+
+                    if track_mode not in cdi_track_modes:
+                        print("Unsupported format: Track mode not supported")
+                    elif track_mode > 0:
+                        track_position = (track_offset + track_pregap_length *
+                                          track_sector_size)
+                        last_data_track_info = (track_position,
+                                                track_sector_size)
+
+                    track_offset += track_total_length * track_sector_size
+
+                    f.seek(29, 1)
+                    if image_version != CDI_V2:
+                        f.seek(5, 1)
+                        temp_value = struct.unpack("<I", f.read(4))[0]
+                        if temp_value == 0xffffffff:
+                            # extra data (DJ 3.00.780 and up)
+                            f.seek(78, 1)
+
+                # Skip to next session
+                f.seek(4, 1)
+                f.seek(8, 1)
+                if image_version != CDI_V2:
+                    f.seek(1, 1)
+
+            # Extract IP.BIN data
+            if last_data_track_info == (None, None):
+                print("Unsupported Image: Data track not found")
+                return
+
+            ip_bin_position = last_data_track_info[0]
+            if last_data_track_info[1] == 2336:
+                ip_bin_position += 8
+            f.seek(ip_bin_position)
+            data = f.read(256)
+
+            props = self.parseBuffer(data)
+            return props
+
+    def parseBuffer(self, data):
+        try:
+            ip_info = (s.decode('ascii').strip() for s in
+                       struct.unpack("<16s16s16s8s8s10s6s16s16s16s128s", data))
+        except (struct.error, UnicodeDecodeError):
+            return {}
+        keys = ('hardware_id', 'maker_id', 'disc_id', 'areas', 'peripherals',
+                'product_id', 'product_version', 'release_date', 'bootfile',
+                'publisher', 'product_name')
+
+        return dict(zip(keys, ip_info))
+
+
+RomInfoParser.registerParser(DreamcastParser())
+
+CDI_V2 = 0x80000004
+CDI_V3 = 0x80000005
+CDI_V35 = 0x80000006
+
+cdi_track_start_mark = (0, 0, 0x01, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF)
+cdi_track_sector_sizes = {
+    0: 2048,
+    1: 2336,
+    2: 2352
+}
+cdi_track_modes = {
+    0: 'audio',
+    1: 'mode1',
+    2: 'mode2'
+}


### PR DESCRIPTION
This is a basic Dreamcast parser for pyrominfo. It currently only supports `*.cdi` and `*.gdi` images (`*.chd` support is missing). On the other hand, this does not introduce additional dependencies (not even for reading iso9660) and also works with Python3.

I'm currently not sure if this matches your coding style. I left out `isValidBuffer()` and put most parsing code into the `parse()` method instead of `parseBuffer()`, since it's impractical to load a 500-1000 MiB image into memory. It uses a lot of `f.seek(x, 1)` and `f.read()`.

**Note:** There is no libretro core supporting dreamcast yet, but I sincerely hope that reicast will see a libretro port at some point. Since pyrominfo does not depend on libretro at all, this should not matter anyway.

**Note 2:** Unittests are still missing, but the [smallest Public Domain CDI image I found](http://www.zophar.net/pdroms/dreamcast/dream-selection-tetris-clone-edition.html) was 11 MiB. That is this somewhat big. I'm too incompetent and lazy to create a custom, stripped down dummy cdi file for these tests, maybe someone from the community can help out.

## Test run
This is the test program I used:
```Python
import pprint
# Import Gameboy support and parse a Dreamcast ROM
from pyrominfo import RomInfo
from pyrominfo import dreamcast

print("CDI test:")
props = RomInfo.parse("Crazy Taxi.cdi")
if props:
    pprint.pprint(props)

print("")

print("GDI test:")
props = RomInfo.parse("Cannon Spike/disc.gdi")
if props:
    pprint.pprint(props)

```
And this is the output:
```Python
CDI test:
{'bootfile': u'1ST_READ.BIN',
 'compatible_peripherals': ('VGA box support',
                            'Analog vertical controller',
                            'Puru Puru pack',
                            'Start/A/B/Directions',
                            'Analog R trigger',
                            'Analog L trigger',
                            'X button',
                            'Memory card',
                            'Analog horizontal controller',
                            'Y button'),
 'compatible_peripherals_code': u'0799A10',
 'game_title': u'CRAZY TAXI',
 'hardware_id': u'SEGA SEGAKATANA',
 'hardware_vendor_id': u'SEGA ENTERPRISES',
 'media_id': u'AD31',
 'media_info': (1, 1),
 'media_info_code': u'GD-ROM1/1',
 'product_id': u'MK-51035',
 'product_version': u'V1.000',
 'publisher': u'ECHELON',
 'region_code': u'JUE',
 'regions': ('Asia', 'America', 'Europe'),
 'release_date': datetime.date(2000, 1, 20),
 'release_date_code': u'20000120'}

GDI test:
{'bootfile': u'1ST_READ.BIN',
 'compatible_peripherals': ('Analog vertical controller',
                            'Start/A/B/Directions',
                            'Analog R trigger',
                            'Analog L trigger',
                            'X button',
                            'Memory card',
                            'Analog horizontal controller',
                            'Y button'),
 'compatible_peripherals_code': u'0799800',
 'game_title': u'CANNON SPIKE',
 'hardware_id': u'SEGA SEGAKATANA',
 'hardware_vendor_id': u'SEGA ENTERPRISES',
 'media_id': u'B158',
 'media_info': (1, 1),
 'media_info_code': u'GD-ROM1/1',
 'product_id': u'T46601D 05',
 'product_version': u'V1.000',
 'publisher': u'SEGA LC-T-466',
 'region_code': u'E',
 'regions': ('Europe',),
 'release_date': datetime.date(2001, 8, 8),
 'release_date_code': u'20010808'}

```